### PR TITLE
fix geoFilter, added test

### DIFF
--- a/DApp/src/component/DirectoriesCollector.ts
+++ b/DApp/src/component/DirectoriesCollector.ts
@@ -88,6 +88,7 @@ export default class DirectoriesCollector implements IDirectoriesCollector{
                        const vs= new VoidSource("", index);
                        vs.setScore(1);//geo filter not passed!
                        ris.push(vs);
+                       Logger.getInstance().addLog(componentName,"GeoFilter not passed for source"+index);
                     }
                 } else if (Config.IGNORE_TD_COLLECTION_ERROR) {
                     ris.push(new VoidSource("", index));

--- a/DApp/src/component/GeoFilter.ts
+++ b/DApp/src/component/GeoFilter.ts
@@ -59,7 +59,7 @@ export default class GeoFilter implements IGeoFilter{
                     const p = [_point.latitude, _point.longitude];
                     points.push(p);
                 }
-                //First and last Position are not equivalent
+                //First and last Position must be equivalent
                 const _point = this.geoFilterQuery.region.vertices[0];
                 const p = [_point.latitude, _point.longitude];
                 points.push(p);
@@ -79,7 +79,11 @@ export default class GeoFilter implements IGeoFilter{
                 if(unit!==undefined){
                     radius= this.convertUnitToKmForm(radius,unit);
                 }
-                this.region = circle(center, radius,{steps: radius/10, units: 'kilometers'});
+                let steps = 100;
+                if( radius/steps>steps){
+                    steps = radius/steps;
+                }
+                this.region = circle(center, radius,{steps: steps, units: 'kilometers'});
             }else{
                 throw new Error("Not valid region.");
             }
@@ -87,18 +91,18 @@ export default class GeoFilter implements IGeoFilter{
             throw new Error("Unsupported geoFilterQuery.");
         }
 
-        if(this.geoFilterQuery.altitudeRange===undefined){
-            this.region=null;
-        }else if(!isNaN(this.geoFilterQuery.altitudeRange.min) && !isNaN(this.geoFilterQuery.altitudeRange.max)){
-            const unit = this.geoFilterQuery.altitudeRange.unit;
-            this.altMin = this.geoFilterQuery.altitudeRange.min;
-            this.altMax = this.geoFilterQuery.altitudeRange.max;
-            if(unit!==undefined){
-                this.altMin= this.convertUnitToMetersForm(this.altMin,unit);
-                this.altMax= this.convertUnitToMetersForm(this.altMax,unit);
-            }
-            this.alt=true;
-        }else{ throw new Error("Not valid altitudeRange."); }
+        if(this.geoFilterQuery?.altitudeRange!==undefined){
+            if(!isNaN(this.geoFilterQuery.altitudeRange.min) && !isNaN(this.geoFilterQuery.altitudeRange.max)){
+                const unit = this.geoFilterQuery.altitudeRange.unit;
+                this.altMin = this.geoFilterQuery.altitudeRange.min;
+                this.altMax = this.geoFilterQuery.altitudeRange.max;
+                if(unit!==undefined){
+                    this.altMin= this.convertUnitToMetersForm(this.altMin,unit);
+                    this.altMax= this.convertUnitToMetersForm(this.altMax,unit);
+                }
+                this.alt=true;
+            }else{ throw new Error("Not valid altitudeRange."); }
+        }
     }
 
  
@@ -106,7 +110,7 @@ export default class GeoFilter implements IGeoFilter{
         let okLatLon = false;
         let okAlt = false;
         if(this.region===null){
-            okLatLon=true;
+            okLatLon=true;  
         }else if(lon!==null && lat!==null){
             const _point = point([lat,lon]);
             const temp = pointsWithinPolygon(_point, this.region).features;

--- a/DApp/src/const/Config.ts
+++ b/DApp/src/const/Config.ts
@@ -32,7 +32,7 @@ export default {
 
     LOGGER_URL:"https://desmold-logs.vaimee.it/logs",
     ONLINE_LOGGER_ENABLE:false,
-    CONSOLE_LOGGER_ENABLE:false,
+    CONSOLE_LOGGER_ENABLE:true,
 
     //that is used only for the local run of the DApp outside the docker image
     DEFAULT_IEXEC_OUT:"/iexec_out",

--- a/DApp/src/model/WotSource.ts
+++ b/DApp/src/model/WotSource.ts
@@ -47,13 +47,25 @@ export default class WotSource implements ISource {
 
     async isGeoValid(geo:IGeoFilter):Promise<boolean>{
         try {
-            const readerLat = await this.thing.readProperty(Config.LATITUDE_PROPS_NAME);
-            let lat = await readerLat.value();
-            const readerLong = await this.thing.readProperty(Config.LONGITUDE_PROPS_NAME);
-            let long = await readerLong.value();
-            const readerAlt = await this.thing.readProperty(Config.ALTITUDE_PROPS_NAME);
-            let alt = await readerAlt.value();
-            Logger.getInstance().addLog(componentName, "isGeoValid, response: lat["+lat+"] lon["+long+"]");
+            let lat =null;
+            let long =null;
+            let alt =null;
+            try{
+                const readerLat = await this.thing.readProperty(Config.LATITUDE_PROPS_NAME);
+                lat = await readerLat.value();
+                const readerLong = await this.thing.readProperty(Config.LONGITUDE_PROPS_NAME);
+                long = await readerLong.value();
+                Logger.getInstance().addLog(componentName, "isGeoValid, response: lat["+lat+"] lon["+long+"]");
+            }catch(err){
+                Logger.getInstance().addLog(componentName, "isGeoValid, lat long not available.");
+            }
+            try{
+                const readerAlt = await this.thing.readProperty(Config.ALTITUDE_PROPS_NAME);
+                alt = await readerAlt.value();
+                Logger.getInstance().addLog(componentName, "isGeoValid, response: alt["+alt+"]");
+            }catch(err){    
+                Logger.getInstance().addLog(componentName, "isGeoValid, altitude not available.");
+            }
             if(lat!==null){
                 lat= Number(lat);
             }

--- a/DApp/tests/geoFilter.test.ts
+++ b/DApp/tests/geoFilter.test.ts
@@ -40,7 +40,17 @@ const geoFilter_02=  {
   }
 };
 
-
+const geoFilter_03= {
+  "region": {
+    "center": {
+      "latitude":41.9109,
+      "longitude": 12.4818
+    },
+    "radius": {
+      "value": 50.0,
+      "unit": "meters"
+    }
+  }};
 
 describe('Testing GeoFilter', () => {
     describe('GeoFilter general', () => {
@@ -142,6 +152,7 @@ describe('Testing GeoFilter', () => {
             const point6= [45.63942, 20.80335];
             const point7= [-73.05673, 39.78844];
             const point8= [-78.60106, 2.83044];
+            const point9= [44.494884, 11.3426162];
             const gf = new GeoFilter(geoFilter_01);
             
             //wring altitude -1m
@@ -161,8 +172,22 @@ describe('Testing GeoFilter', () => {
             expect(gf.isInside(point6[0],point6[1],55000)).toBeFalsy();
             expect(gf.isInside(point7[0],point7[1],55000)).toBeFalsy();
             expect(gf.isInside(point8[0],point8[1],55000)).toBeFalsy();
+            expect(gf.isInside(point9[0],point9[1],55000)).toBeFalsy();
 
         });
+
+        it('Testing a realy small region filter', async () => {
+  
+          //good points
+          const point1= [41.910911, 12.4818999];
+          //bad points
+          const point2= [44.494888, 11.3426163];
+          const gf = new GeoFilter(geoFilter_03);
+     
+          expect(gf.isInside(point1[0],point1[1],null)).toBeTruthy();
+          expect(gf.isInside(point2[0],point2[1],null)).toBeFalsy();
+
+      });
       
     });
     


### PR DESCRIPTION
Hi!
Here we have some fixes for the GeoFilter.

2 examples of use cases, that you can test.

This should give you a result:

`npm start -- 0x000000000000000000000000000000000000000000000000000000000000000b '{__!_prefixList__!_:[{__!_abbreviation__!_:__!_desmo__!_,__!_completeURI__!_:__!_https://desmo.vaimee.it/__!_},{__!_abbreviation__!_:__!_qudt__!_,__!_completeURI__!_:__!_http://qudt.org/schema/qudt/__!_},{__!_abbreviation__!_:__!_xsd__!_,__!_completeURI__!_:__!_http://www.w3.org/2001/XMLSchema/__!_},{__!_abbreviation__!_:__!_monas__!_,__!_completeURI__!_:__!_https://pod.dasibreaker.vaimee.it/monas/__!_}],__!_property__!_:{__!_identifier__!_:__!_value__!_,__!_unit__!_:__!_qudt:DEG_C__!_,__!_datatype__!_:1},__!_geoFilter__!_:{__!_region__!_:{__!_center__!_:{__!_latitude__!_:41.9109,__!_longitude__!_:12.4818},__!_radius__!_:{__!_value__!_:50.0,__!_unit__!_:__!_qudt:KiloM__!_}}},__!_staticFilter__!_:__!_$[?(@[--#-type--#-]==--#-Sensor--#-)]__!_}'`



This should give you `!ERROR!: Impossible to reach consensus code[01]: no sources.` as output for ` GeoFilter not passed `:

`npm start -- 0x000000000000000000000000000000000000000000000000000000000000000b '{__!_prefixList__!_:[{__!_abbreviation__!_:__!_desmo__!_,__!_completeURI__!_:__!_https://desmo.vaimee.it/__!_},{__!_abbreviation__!_:__!_qudt__!_,__!_completeURI__!_:__!_http://qudt.org/schema/qudt/__!_},{__!_abbreviation__!_:__!_xsd__!_,__!_completeURI__!_:__!_http://www.w3.org/2001/XMLSchema/__!_},{__!_abbreviation__!_:__!_monas__!_,__!_completeURI__!_:__!_https://pod.dasibreaker.vaimee.it/monas/__!_}],__!_property__!_:{__!_identifier__!_:__!_value__!_,__!_unit__!_:__!_qudt:DEG_C__!_,__!_datatype__!_:1},__!_geoFilter__!_:{__!_region__!_:{__!_center__!_:{__!_latitude__!_:41.9109,__!_longitude__!_:12.4818},__!_radius__!_:{__!_value__!_:50.0,__!_unit__!_:__!_qudt:M__!_}}},__!_staticFilter__!_:__!_$[?(@[--#-type--#-]==--#-Sensor--#-)]__!_}'`